### PR TITLE
CAF-2992: Adjusted usages of private networking hostnames to correct ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -10,7 +10,7 @@ services:
     environment:
       cluster.name: "elasticsearch-cluster"
       ES_JAVA_OPTS: "${ES_JAVA_OPTS:--Xmx512m -Xms512m}"
-      discovery.zen.ping.unicast.hosts: "elasticsearch2:${ELASTICSEARCH_NETWORK_PORT_NODE2:-9301},elasticsearch3:${ELASTICSEARCH_NETWORK_PORT_NODE3:-9302}"
+      discovery.zen.ping.unicast.hosts: "elasticsearch2:9300,elasticsearch3:9300"
       # disable X-Pack
       # see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
       #     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
@@ -40,7 +40,7 @@ services:
     environment:
       cluster.name: "elasticsearch-cluster"
       ES_JAVA_OPTS: "${ES_JAVA_OPTS:--Xmx512m -Xms512m}"
-      discovery.zen.ping.unicast.hosts: "elasticsearch1:${ELASTICSEARCH_NETWORK_PORT_NODE1:-9300},elasticsearch3:${ELASTICSEARCH_NETWORK_PORT_NODE3:-9302}"
+      discovery.zen.ping.unicast.hosts: "elasticsearch1:9300,elasticsearch3:9300"
       # disable X-Pack
       # see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
       #     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
@@ -70,7 +70,7 @@ services:
     environment:
       cluster.name: "elasticsearch-cluster"
       ES_JAVA_OPTS: "${ES_JAVA_OPTS:--Xmx512m -Xms512m}"
-      discovery.zen.ping.unicast.hosts: "elasticsearch1:${ELASTICSEARCH_NETWORK_PORT_NODE1:-9300},elasticsearch2:${ELASTICSEARCH_NETWORK_PORT_NODE2:-9301}"
+      discovery.zen.ping.unicast.hosts: "elasticsearch1:9300,elasticsearch2:9300"
       # disable X-Pack
       # see https://www.elastic.co/guide/en/x-pack/current/xpack-settings.html
       #     https://www.elastic.co/guide/en/x-pack/current/installing-xpack.html#xpack-enabling
@@ -97,11 +97,11 @@ services:
       - elasticsearch1
       - elasticsearch2
       - elasticsearch3
-    image: rh7-artifactory.svs.hpeswlab.net:8443/caf/audit-service:3.1.0-SNAPSHOT
+    image: rh7-artifactory.svs.hpeswlab.net:8443/caf/audit-service:3.2.0-SNAPSHOT
     ports:
       - "${CAF_AUDIT_SERVICE_PORT:-25080}:8080"
     environment:
-      CAF_ELASTIC_HOST_AND_PORT: elasticsearch1:${ELASTICSEARCH_NETWORK_PORT_NODE1:-9300},elasticsearch2:${ELASTICSEARCH_NETWORK_PORT_NODE2:-9301},elasticsearch3:${ELASTICSEARCH_NETWORK_PORT_NODE3:-9302}
+      CAF_ELASTIC_HOST_AND_PORT: elasticsearch1:9300,elasticsearch2:9300,elasticsearch3:9300
       CAF_ELASTIC_CLUSTER_NAME: elasticsearch-cluster
       CAF_ELASTIC_NUMBER_OF_SHARDS: 5
       CAF_ELASTIC_NUMBER_OF_REPLICAS: 1


### PR DESCRIPTION
The adjustments to the "discovery.zen.ping.unicast.hosts", ES instances' environment variable, appears to correct data sync issues across nodes when bringing a node up and down with data in-between those stops and starts.

The adjustment to the "CAF_ELASTIC_HOST_AND_PORT" Web Service environment variable stops the "connection refused" INFO logging from the Web Service's log (solves one of the issues detailed here: https://jira.autonomy.com/browse/CAF-2992 )