### PR TITLE
CAF-1640: Create smoke testing for Audit Service

### DIFF
--- a/production-marathon/README.md
+++ b/production-marathon/README.md
@@ -14,7 +14,7 @@ The `marathon.env` file supports configurable property settings necessary for se
 
 - `CAF_AUDIT_SERVICE_PORT`: This property configures the port that the CAF Audit Web Service listens on. 
 
-- `CAF_ELASTIC_HOST_AND_PORT`: This setting configures a comma separated list of Elasticsearch HOST:PORT value pairs. e.g. 192.168.56.10:9300,192.168.56.20:9300.
+- `CAF_ELASTIC_HOST_AND_PORT`: This setting configures a comma separated list of Elasticsearch HOST:TRANSPORT_PORT value pairs. e.g. 192.168.56.10:9300,192.168.56.20:9300.
 
 - `CAF_ELASTIC_CLUSTER_NAME`: This configures the name of the Elasticsearch cluster. e.g. elasticsearch. 
 
@@ -47,4 +47,4 @@ In order to deploy the service application, issue the following command from the
 	source ./marathon.env ; \
 		cat marathon.json.b \
 		| perl -pe 's/\$\{(\w+)\}/(exists $ENV{$1} && length $ENV{$1} > 0 ? $ENV{$1} : "NOT_SET_$1")/eg' \
-		| curl -H "Content-Type: application/json" -d @- http://localhost:8080/v2/groups/
+		| curl -H "Content-Type: application/json" -d @- http://localhost:8080/v2/groups/caf

--- a/production-marathon/marathon.env
+++ b/production-marathon/marathon.env
@@ -6,7 +6,7 @@ export DOCKER_REGISTRY=
 # The port that the CAF Audit Web Service is configured to listen on.
 export CAF_AUDIT_SERVICE_PORT=
 
-# A comma separated list of Elasticsearch HOST:PORT value pairs.
+# A comma separated list of Elasticsearch HOST:TRANSPORT_PORT value pairs.
 export CAF_ELASTIC_HOST_AND_PORT=
 
 # The name of the Elasticsearch cluster.

--- a/production-marathon/marathon.json.b
+++ b/production-marathon/marathon.json.b
@@ -1,43 +1,40 @@
 {
-	"id": "caf",
-	"groups": [{
-		"id": "audit",
-		"apps": [{
-			"id": "audit-service",
-			"cpus": 0.25,
-			"mem": 768,
-			"instances": 1,
-			"container": {
-				"docker": {
-					"image": "${DOCKER_REGISTRY}/audit-service:3.1.0",
-					"network": "BRIDGE",
-					"portMappings": [{
-						"containerPort": 8080,
-						"hostPort": 0,
-						"protocol": "tcp",
-						"servicePort": ${CAF_AUDIT_SERVICE_PORT}
-					}],
-					"forcePullImage": true
-				},
-				"type": "DOCKER"
-			},
-			"env": {
-				"_JAVA_OPTIONS": "-Xms384m -Xmx384m",
-				"CAF_ELASTIC_HOST_AND_PORT": "${CAF_ELASTIC_HOST_AND_PORT}",
-				"CAF_ELASTIC_CLUSTER_NAME": "${CAF_ELASTIC_CLUSTER_NAME}",
-				"CAF_ELASTIC_NUMBER_OF_REPLICAS": "1",
-				"CAF_ELASTIC_NUMBER_OF_SHARDS": "5",
-				"CAF_LOG_LEVEL": "INFO"
-			},
-			"healthChecks": [{
-				"gracePeriodSeconds": 300,
-				"intervalSeconds": 60,
-				"maxConsecutiveFailures": 3,
-				"path": "/",
-				"portIndex": 0,
-				"protocol": "HTTP",
-				"timeoutSeconds": 20
-			}]
-		}]
-	}]
+    "id": "audit-prod",
+    "apps": [{
+        "id": "audit-service",
+        "cpus": 0.25,
+        "mem": 768,
+        "instances": 1,
+        "container": {
+            "docker": {
+                "image": "${DOCKER_REGISTRY}/audit-service:3.1.0",
+                "network": "BRIDGE",
+                "portMappings": [{
+                    "containerPort": 8080,
+                    "hostPort": 0,
+                    "protocol": "tcp",
+                    "servicePort": ${CAF_AUDIT_SERVICE_PORT}
+                }],
+                "forcePullImage": true
+            },
+            "type": "DOCKER"
+        },
+        "env": {
+            "_JAVA_OPTIONS": "-Xms384m -Xmx384m",
+            "CAF_ELASTIC_HOST_AND_PORT": "${CAF_ELASTIC_HOST_AND_PORT}",
+            "CAF_ELASTIC_CLUSTER_NAME": "${CAF_ELASTIC_CLUSTER_NAME}",
+            "CAF_ELASTIC_NUMBER_OF_REPLICAS": "1",
+            "CAF_ELASTIC_NUMBER_OF_SHARDS": "5",
+            "CAF_LOG_LEVEL": "INFO"
+        },
+        "healthChecks": [{
+            "gracePeriodSeconds": 300,
+            "intervalSeconds": 60,
+            "maxConsecutiveFailures": 3,
+            "path": "/",
+            "portIndex": 0,
+            "protocol": "HTTP",
+            "timeoutSeconds": 20
+        }]
+    }]
 }

--- a/production-marathon/smoke-testing/README.md
+++ b/production-marathon/smoke-testing/README.md
@@ -43,7 +43,7 @@ Further information on the CAF Audit Monkey can be found [here](https://github.c
 
 ### Sending Audit Events Direct to Elasticsearch
 
-From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [directtestid], [direct] to Elasticsearch in [Standard] mode using [1] threads. Replace the `ES_HOSTNAME`, `ES_PORT` and `ES_CLUSTERNAME` environment variables with the details of the Elasticsearch deployed for smoke testing purposes:
+From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [directtestid], [direct] to Elasticsearch in [Standard] mode using [1] thread. Replace the `ES_HOSTNAME`, `ES_PORT` and `ES_CLUSTERNAME` environment variables with the details of the Elasticsearch deployed for smoke testing purposes:
 
 ```
 docker run -e ES_HOSTNAME=<Elasticsearch_Node> -e ES_PORT=<Elasticsearch_Node_Transport_Port> -e ES_CLUSTERNAME=<Elasticsearch_Cluster_Name> -e CAF_AUDIT_TENANT_ID=directtestid -e CAF_AUDIT_MODE=direct -e CAF_AUDIT_MONKEY_MODE=standard -e CAF_AUDIT_MONKEY_NUM_OF_EVENTS=2 -e CAF_AUDIT_MONKEY_NUM_OF_THREADS=1 cafaudit/audit-monkey:3.2.0

--- a/production-marathon/smoke-testing/README.md
+++ b/production-marathon/smoke-testing/README.md
@@ -1,0 +1,73 @@
+# Deployment for Smoke Testing
+
+This guide covers the deployment of Elasticsearch with the CAF Audit Web Service and CAF Audit Monkey for smoke testing. The CAF Audit Monkey is used to test the logging of audit events directly to Elastic and through the CAF Audit Web Service.
+
+This folder contains the marathon environment and template files that are required to deploy Elasticsearch for smoke testing of the CAF Audit Web Service on Mesos/Marathon.
+
+## Elasticsearch Configuration
+
+### Marathon Template
+
+The `marathon-testing-elasticsearch.json.b` template file describes the marathon deployment information required for Elasticsearch. The template file uses property substitution to get values for configurable properties **required** for service deployment. These properties are configured in the marathon-testing environment file. 
+
+### Marathon Environment
+
+The `marathon-testing.env` file supports configurable property settings necessary for Elasticsearch deployment. These include:
+
+- `CAF_TESTING_ELASTICSEARCH_HTTP_SERVICE_PORT`: This property configures the port that the Elasticsearch HTTP Service is configured to listen on. 
+
+- `CAF_TESTING_ELASTICSEARCH_TRANSPORT_SERVICE_PORT`: This property configures the port that the Elasticsearch Transport Service is configured to listen on. 
+
+- `CAF_ELASTIC_CLUSTER_NAME`: This configures the name of the Elasticsearch cluster. e.g. audit-smoketest-elasticsearch. 
+
+Please note that Elasticsearch cannot be deployed unless all of the above properties are configured in the marathon environment file.
+
+## Elasticsearch Deployment
+
+In order to deploy Elasticsearch, issue the following command from the 'production-marathon/smoke-testing' directory:
+
+	source ./marathon-testing.env ; \
+		cat marathon-testing-elasticsearch.json.b \
+		| perl -pe 's/\$\{(\w+)\}/(exists $ENV{$1} && length $ENV{$1} > 0 ? $ENV{$1} : "NOT_SET_$1")/eg' \
+		| curl -H "Content-Type: application/json" -d @- http://localhost:8080/v2/groups/caf
+
+## CAF Audit Web Service Deployment
+
+After Elasticsearch has started follow the 'production-marathon/README.md' for deployment of the CAF Audit Web Service and configure the `marathon.env` properties to match with the Elasticsearch deployed for smoke testing.
+
+## CAF Audit Monkey Usage
+
+The Audit Monkey provides the ability to send Audit Events both directly to Elasticsearch and via the CAF Audit Web Service.
+
+Further information on the CAF Audit Monkey can be found [here](https://github.com/CAFAudit/audit-service/tree/develop/caf-audit-monkey).
+
+### Sending Audit Events Direct to Elasticsearch
+
+From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [directtestid], [direct] to Elasticsearch in [Standard] mode using [1] threads. Replace the `ES_HOSTNAME`, `ES_PORT` and `ES_CLUSTERNAME` environment variables with the details of the Elasticsearch deployed for smoke testing purposes:
+
+```
+docker run -e ES_HOSTNAME=<Elasticsearch_Node> -e ES_PORT=<Elasticsearch_Node_Transport_Port> -e ES_CLUSTERNAME=<Elasticsearch_Cluster_Name> -e CAF_AUDIT_TENANT_ID=directtestid -e CAF_AUDIT_MODE=direct -e CAF_AUDIT_MONKEY_MODE=standard -e CAF_AUDIT_MONKEY_NUM_OF_EVENTS=2 -e CAF_AUDIT_MONKEY_NUM_OF_THREADS=1 cafaudit/audit-monkey:3.2.0
+```
+
+#### Verification of Direct to Elasticsearch Audit Events
+
+The following CURL command will return all of the Tenant Id's [directtestid] audit events stored in Elasticsearch. There should be two hits returned:
+
+```
+curl --request GET --url 'http://<Elasticsearch_Node>:<Elasticsearch_Node_HTTP_Port>/directtestid_audit/cafAuditEvent/_search?pretty='
+```
+
+### Sending Audit Events via CAF Audit Web Service
+
+From your Docker host command-line, run the Audit Monkey sending [2] Audit Events, for Tenant Id [wstestid], through the [Audit Web Service] in [Standard] mode using [1] thread. Replace the `WS_HOSTNAME` and `WS_PORT` environment variables with the details of the CAF Audit Web Service deployed for smoke testing purposes:
+
+```
+docker run -e CAF_AUDIT_TENANT_ID=wstestid -e CAF_AUDIT_MODE=webservice -e WS_HOSTNAME=<CAF_Audit_Web_Service_Host> -e WS_PORT=<CAF_Audit_Web_Service_Port> -e CAF_AUDIT_MONKEY_MODE=standard -e CAF_AUDIT_MONKEY_NUM_OF_EVENTS=2 -e CAF_AUDIT_MONKEY_NUM_OF_THREADS=1 cafaudit/audit-monkey:3.2.0
+```
+#### Verification of Audit Events
+
+The following CURL command will return all of the Tenant Id's [wstestid] audit events stored in Elasticsearch. There should be two hits returned:
+
+```
+curl --request GET --url 'http://<Elasticsearch_Node>:<Elasticsearch_Node_HTTP_Port>/wstestid_audit/cafAuditEvent/_search?pretty='
+```

--- a/production-marathon/smoke-testing/marathon-testing-elasticsearch.json.b
+++ b/production-marathon/smoke-testing/marathon-testing-elasticsearch.json.b
@@ -4,7 +4,7 @@
         "container": {
             "docker": {
                 "forcePullImage": true,
-                "image": "docker.elastic.co/elasticsearch/elasticsearch:5.3.0",
+                "image": "docker.elastic.co/elasticsearch/elasticsearch:5.3.1",
                 "network": "BRIDGE",
                 "portMappings": [
                     {

--- a/production-marathon/smoke-testing/marathon-testing-elasticsearch.json.b
+++ b/production-marathon/smoke-testing/marathon-testing-elasticsearch.json.b
@@ -1,0 +1,55 @@
+{
+    "id": "audit-testing",
+    "apps": [{
+        "container": {
+            "docker": {
+                "forcePullImage": true,
+                "image": "docker.elastic.co/elasticsearch/elasticsearch:5.3.0",
+                "network": "BRIDGE",
+                "portMappings": [
+                    {
+                        "containerPort": 9200,
+                        "hostPort": 0,
+                        "protocol": "tcp",
+                        "servicePort": ${CAF_TESTING_ELASTICSEARCH_HTTP_SERVICE_PORT}
+                    },
+                    {
+                        "containerPort": 9300,
+                        "hostPort": 0,
+                        "protocol": "tcp",
+                        "servicePort": ${CAF_TESTING_ELASTICSEARCH_TRANSPORT_SERVICE_PORT}
+                    }
+                ],
+                "parameters": [
+                    { "key": "ulimit", "value": "memlock=-1:-1" },
+                    { "key": "ulimit", "value": "nofile=65536:65536" }
+                ]
+            },
+            "type": "DOCKER"
+        },
+        "cpus": 0.4,
+        "env": {
+            "ES_JAVA_OPTS": "-Xms256m -Xmx256m",
+            "bootstrap.memory_lock": "true",
+            "xpack.graph.enabled": "false",
+            "xpack.monitoring.enabled": "false",
+            "xpack.security.enabled": "false",
+            "xpack.watcher.enabled": "false",
+            "cluster.name": "${CAF_ELASTIC_CLUSTER_NAME}"
+        },
+        "healthChecks": [
+            {
+                "gracePeriodSeconds": 300,
+                "intervalSeconds": 60,
+                "maxConsecutiveFailures": 3,
+                "path": "/",
+                "portIndex": 0,
+                "protocol": "HTTP",
+                "timeoutSeconds": 20
+            }
+        ],
+        "id": "smoke-test-elasticsearch",
+        "instances": 1,
+        "mem": 2048
+    }]
+}

--- a/production-marathon/smoke-testing/marathon-testing.env
+++ b/production-marathon/smoke-testing/marathon-testing.env
@@ -1,0 +1,10 @@
+# The following properties MUST be configured before Elasticsearch for smoke testing can be deployed.
+
+# The port that the Elasticsearch HTTP Service is configured to listen on.
+export CAF_TESTING_ELASTICSEARCH_HTTP_SERVICE_PORT=
+
+# The port that the Elasticsearch Transport Service is configured to listen on.
+export CAF_TESTING_ELASTICSEARCH_TRANSPORT_SERVICE_PORT=
+
+# The name of the Elasticsearch cluster.
+export CAF_ELASTIC_CLUSTER_NAME=


### PR DESCRIPTION
- Removed caf root level Marathon group from CAF Audit Web Service Marathon production deployment JSON. Modified README deploy instruction command to supply root level name of Marathon group. Modified README and Marathon.env to make clear that it is the ES node transport port(s) that are required for configuration.
- Added smoke testing deployment of ES and instructions on how to smoke test Audit direct to ES and Audit via the Audit Web Service with the use of the Audit Monkey.